### PR TITLE
Enable CI via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: python
+python:
+  - "3.6"
+  - "3.7"
+install: pip install tox-travis
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+dist: xenial
+sudo: required
 language: python
 python:
   - "3.6"


### PR DESCRIPTION
Add a Travis CI config so tests are run for supported versions of Python, automatically via tox.
(You'll need to add this repo to your Travis account for test to actually run.)