### PR TITLE
Add CLI entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,4 +33,9 @@ setup(
     },
     tests_require=['pytest'],
     setup_requires=['pytest-runner'],
+    entry_points={
+        'console_scripts': [
+            'dndme = dndme.shell:main_loop',
+        ],
+    }
 )


### PR DESCRIPTION
Adds an entry point so the tool can be installed and run as `dndme` rather than having to be invoked via `python -m module` or `python path/to/script.py`.