### PR TITLE
Fixed wildcard lookup for unstash and remove

### DIFF
--- a/dndme/commands/remove_combatant.py
+++ b/dndme/commands/remove_combatant.py
@@ -27,21 +27,22 @@ Examples:
                 set(names_already_chosen))
 
     def do_command(self, *args):
+        game = self.game
         combat = self.game.combat
-        targets = combat.get_targets(args)
+        targets = combat.get_targets(args) + game.get_stash_targets(args)
         if not targets:
             print(f"No targets found from `{args}`")
             return
 
         for target in targets:
-            if target and hasattr(target, 'mtype'):
-                if combat.tm:
-                    combat.tm.remove_combatant(target)
-                combat.monsters.pop(target.name)
-                print(f"Removed {target.name}")
-                self.game.changed = True
-            elif target.name in self.game.stash and \
-                    hasattr(self.game.stash[target.name], 'mtype'):
-                self.game.stash.pop(target.name)
-                print(f"Removed {target.name} from stash")
-                self.game.changed = True
+            if hasattr(target, 'mtype'):
+                if target.name in combat.monsters:
+                    if combat.tm:
+                        combat.tm.remove_combatant(target)
+                    combat.monsters.pop(target.name)
+                    print(f"Removed {target.name}")
+                    self.game.changed = True
+                elif target.name in game.stash:
+                    self.game.stash.pop(target.name)
+                    print(f"Removed {target.name} from stash")
+                    self.game.changed = True

--- a/dndme/commands/unstash_combatant.py
+++ b/dndme/commands/unstash_combatant.py
@@ -25,27 +25,29 @@ Examples:
     def do_command(self, *args):
         combat = self.game.combat
 
-        for target_name in args:
-            if target_name not in self.game.stash:
-                print(f"Invalid target: {target_name}")
-                continue
+        targets = self.game.get_stash_targets(args)
 
-            target = self.game.stash.pop(target_name)
+        if not targets:
+            print(f"No targets found in stash from `{args}`")
+            return
+
+        for target in targets:
+            target = self.game.stash.pop(target.name)
 
             if hasattr(target, 'mtype'):
-                combat.monsters[target_name] = target
+                combat.monsters[target.name] = target
             else:
-                combat.characters[target_name] = target
+                combat.characters[target.name] = target
 
-            print(f"Unstashed {target_name}")
+            print(f"Unstashed {target.name}")
             self.game.changed = True
 
             if combat.tm:
                 roll_advice = f"1d20{target.initiative_mod:+}" \
-                        if target.initiative_mod else "1d20"
+                    if target.initiative_mod else "1d20"
                 roll = self.safe_input(
-                        f"Initiative for {target.name}",
-                        default=roll_advice,
-                        converter=convert_to_int_or_dice_expr)
+                    f"Initiative for {target.name}",
+                    default=roll_advice,
+                    converter=convert_to_int_or_dice_expr)
                 combat.tm.add_combatant(target, roll)
                 print(f"Added to turn order in {roll}")

--- a/dndme/models.py
+++ b/dndme/models.py
@@ -252,6 +252,20 @@ class Game:
         return combat
 
     @property
+    def get_stash_names(self):
+        return self.stash.keys()
+
+    def get_stash_target(self, name):
+        return self.stash.get(name)
+
+    def get_stash_targets(self, names):
+        matched_names = sorted(set([name for lst in
+                                    [fnmatch.filter(self.get_stash_names, name) for name in names]
+                                    for name in lst]))
+        targets = [self.get_stash_target(name) for name in matched_names]
+        return [target for target in targets if target]
+
+    @property
     def stashed_monster_names(self):
         return [k for k, v in self.stash.items() if hasattr(v, 'mtype')]
 


### PR DESCRIPTION
* Added wildcard lookup of stash targets to class Game.
* Modified  "unstash" command to allow wildcard matching of targets in the stash.
* Modified "remove" command to allow wildcard matching of targets in both the current combat and the stash. Players will not be removed.

Example:

```
Load encounter: 1
Loaded encounter: LMoP 1.1.1: Goblin Ambush with 4 monsters

> stash goblin-01/a253
Stashed goblin-01/a253

> stash goblin-02/0032
Stashed goblin-02/0032

> show stash
goblin-01/a253       LMoP 1.1.1: Goblin Ambush (Triboar Trail)
goblin-02/0032       LMoP 1.1.1: Goblin Ambush (Triboar Trail)

> unstash gob*
Unstashed goblin-01/a253
Unstashed goblin-02/0032

> stash goblin-01/a253
Stashed goblin-01/a253

> stash goblin-02/0032
Stashed goblin-02/0032

> show monsters
( ) goblin-03/69be:Goblin 3             HP: 07/07       AC: 15  Per: 09 hostile
( ) goblin-04/93a0:Goblin 4             HP: 04/04       AC: 15  Per: 09 hostile

> show stash
goblin-01/a253       LMoP 1.1.1: Goblin Ambush (Triboar Trail)
goblin-02/0032       LMoP 1.1.1: Goblin Ambush (Triboar Trail)

> remove gob*
Removed goblin-03/69be
Removed goblin-04/93a0
Removed goblin-01/a253 from stash
Removed goblin-02/0032 from stash
```